### PR TITLE
[feature] 카테고리별 이벤트 리스트 조회 / 유저 API 구현

### DIFF
--- a/src/main/java/com/gotogether/domain/event/controller/EventController.java
+++ b/src/main/java/com/gotogether/domain/event/controller/EventController.java
@@ -1,5 +1,20 @@
 package com.gotogether.domain.event.controller;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.gotogether.domain.event.dto.request.EventRequestDTO;
 import com.gotogether.domain.event.dto.response.EventDetailResponseDTO;
 import com.gotogether.domain.event.dto.response.EventListResponseDTO;
@@ -7,13 +22,8 @@ import com.gotogether.domain.event.entity.Category;
 import com.gotogether.domain.event.entity.Event;
 import com.gotogether.domain.event.service.EventService;
 import com.gotogether.global.apipayload.ApiResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -68,9 +78,9 @@ public class EventController {
 
 	@GetMapping("/categories")
 	public ApiResponse<List<EventListResponseDTO>> getEventsByCategory(
-        @RequestParam(name = "category") Category category,
-        @RequestParam(value = "page", defaultValue = "0") int page,
-        @RequestParam(value = "size", defaultValue = "10") int size) {
+		@RequestParam(name = "category") Category category,
+		@RequestParam(value = "page", defaultValue = "0") int page,
+		@RequestParam(value = "size", defaultValue = "10") int size) {
 		Pageable pageable = PageRequest.of(page, size);
 		Page<EventListResponseDTO> events = eventService.getEventsByCategory(category, pageable);
 		return ApiResponse.onSuccess(events.getContent());

--- a/src/main/java/com/gotogether/domain/event/controller/EventController.java
+++ b/src/main/java/com/gotogether/domain/event/controller/EventController.java
@@ -1,28 +1,19 @@
 package com.gotogether.domain.event.controller;
 
-import java.util.List;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.gotogether.domain.event.dto.request.EventRequestDTO;
 import com.gotogether.domain.event.dto.response.EventDetailResponseDTO;
 import com.gotogether.domain.event.dto.response.EventListResponseDTO;
+import com.gotogether.domain.event.entity.Category;
 import com.gotogether.domain.event.entity.Event;
 import com.gotogether.domain.event.service.EventService;
 import com.gotogether.global.apipayload.ApiResponse;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,19 +28,19 @@ public class EventController {
 		return ApiResponse.onSuccessCreated("eventId: " + event.getId());
 	}
 
-	@GetMapping("{eventId}")
+	@GetMapping("/{eventId}")
 	public ApiResponse<EventDetailResponseDTO> getDetailEvent(@PathVariable Long eventId) {
 		return ApiResponse.onSuccess(eventService.getDetailEvent(eventId));
 	}
 
-	@PutMapping("{eventId}")
+	@PutMapping("/{eventId}")
 	public ApiResponse<?> updateEvent(@PathVariable Long eventId,
 		@RequestBody EventRequestDTO request) {
 		Event event = eventService.updateEvent(eventId, request);
 		return ApiResponse.onSuccess("eventId: " + event.getId());
 	}
 
-	@DeleteMapping("{eventId}")
+	@DeleteMapping("/{eventId}")
 	public ApiResponse<?> deleteEvent(@PathVariable Long eventId) {
 		eventService.deleteEvent(eventId);
 		return ApiResponse.onSuccess("이벤트 삭제 성공");
@@ -72,6 +63,16 @@ public class EventController {
 		@RequestParam(value = "size", defaultValue = "10") int size) {
 		Pageable pageable = PageRequest.of(page, size);
 		Page<EventListResponseDTO> events = eventService.searchEvents(keyword, pageable);
+		return ApiResponse.onSuccess(events.getContent());
+	}
+
+	@GetMapping("/categories")
+	public ApiResponse<List<EventListResponseDTO>> getEventsByCategory(
+        @RequestParam(name = "category") Category category,
+        @RequestParam(value = "page", defaultValue = "0") int page,
+        @RequestParam(value = "size", defaultValue = "10") int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<EventListResponseDTO> events = eventService.getEventsByCategory(category, pageable);
 		return ApiResponse.onSuccess(events.getContent());
 	}
 }

--- a/src/main/java/com/gotogether/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/gotogether/domain/event/repository/EventRepository.java
@@ -1,5 +1,6 @@
 package com.gotogether.domain.event.repository;
 
+import com.gotogether.domain.event.entity.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -28,4 +29,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 		"AND e.endDate >= CURRENT_TIMESTAMP " +
 		"ORDER BY e.createdAt DESC")
 	Page<Event> findEventsByFilter(@Param("keyword") String keyword, Pageable pageable);
+
+	Page<Event> findByCategory(Category category, Pageable pageable);
 }

--- a/src/main/java/com/gotogether/domain/event/service/EventService.java
+++ b/src/main/java/com/gotogether/domain/event/service/EventService.java
@@ -1,5 +1,6 @@
 package com.gotogether.domain.event.service;
 
+import com.gotogether.domain.event.entity.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -20,4 +21,6 @@ public interface EventService {
 	Page<EventListResponseDTO> getEventsByTag(String tags, Pageable pageable);
 
 	Page<EventListResponseDTO> searchEvents(String keyword, Pageable pageable);
+
+    Page<EventListResponseDTO> getEventsByCategory(Category category, Pageable pageable);
 }

--- a/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
@@ -3,6 +3,7 @@ package com.gotogether.domain.event.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.gotogether.domain.event.entity.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -122,6 +123,13 @@ public class EventServiceImpl implements EventService {
 	@Transactional(readOnly = true)
 	public Page<EventListResponseDTO> searchEvents(String keyword, Pageable pageable) {
 		Page<Event> events = eventRepository.findEventsByFilter(keyword, pageable);
+		return events.map(EventConverter::toEventListResponseDTO);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Page<EventListResponseDTO> getEventsByCategory(Category category, Pageable pageable) {
+		Page<Event> events = eventRepository.findByCategory(category, pageable);
 		return events.map(EventConverter::toEventListResponseDTO);
 	}
 

--- a/src/main/java/com/gotogether/domain/user/controller/UserController.java
+++ b/src/main/java/com/gotogether/domain/user/controller/UserController.java
@@ -1,7 +1,27 @@
 package com.gotogether.domain.user.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.gotogether.domain.user.dto.request.UserRequestDTO;
+import com.gotogether.domain.user.entity.User;
+import com.gotogether.domain.user.service.UserService;
+import com.gotogether.global.apipayload.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping("/sign-up")
+	public ApiResponse<?> signUp(@RequestBody UserRequestDTO request) {
+		User user = userService.createUser(request);
+		return ApiResponse.onSuccessCreated(user.getId());
+	}
 }

--- a/src/main/java/com/gotogether/domain/user/controller/UserController.java
+++ b/src/main/java/com/gotogether/domain/user/controller/UserController.java
@@ -1,13 +1,16 @@
 package com.gotogether.domain.user.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.gotogether.domain.user.dto.request.UserRequestDTO;
+import com.gotogether.domain.user.dto.response.UserDetailResponseDTO;
 import com.gotogether.domain.user.entity.User;
 import com.gotogether.domain.user.service.UserService;
+import com.gotogether.global.annotation.AuthUser;
 import com.gotogether.global.apipayload.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -22,6 +25,12 @@ public class UserController {
 	@PostMapping("/sign-up")
 	public ApiResponse<?> signUp(@RequestBody UserRequestDTO request) {
 		User user = userService.createUser(request);
-		return ApiResponse.onSuccessCreated(user.getId());
+		return ApiResponse.onSuccessCreated("userId: " + user.getId());
+	}
+
+	@GetMapping
+	public ApiResponse<UserDetailResponseDTO> getDetailUser(@AuthUser Long userId) {
+		UserDetailResponseDTO response = userService.getDetailUser(userId);
+		return ApiResponse.onSuccess(response);
 	}
 }

--- a/src/main/java/com/gotogether/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/gotogether/domain/user/converter/UserConverter.java
@@ -1,0 +1,16 @@
+package com.gotogether.domain.user.converter;
+
+import com.gotogether.domain.user.dto.response.UserDetailResponseDTO;
+import com.gotogether.domain.user.entity.User;
+
+public class UserConverter {
+
+	public static UserDetailResponseDTO toUserDetailResponseDTO(User user) {
+		return UserDetailResponseDTO.builder()
+			.id(user.getId())
+			.name(user.getName())
+			.phoneNumber(user.getPhoneNumber())
+			.email(user.getEmail())
+			.build();
+	}
+}

--- a/src/main/java/com/gotogether/domain/user/dto/request/UserRequestDTO.java
+++ b/src/main/java/com/gotogether/domain/user/dto/request/UserRequestDTO.java
@@ -1,0 +1,13 @@
+package com.gotogether.domain.user.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserRequestDTO {
+	private Long id;
+	private String name;
+	private String phoneNumber;
+	private String email;
+}

--- a/src/main/java/com/gotogether/domain/user/dto/response/UserDetailResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/user/dto/response/UserDetailResponseDTO.java
@@ -1,0 +1,13 @@
+package com.gotogether.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserDetailResponseDTO {
+	private Long id;
+	private String name;
+	private String phoneNumber;
+	private String email;
+}

--- a/src/main/java/com/gotogether/domain/user/dto/response/package-info.java
+++ b/src/main/java/com/gotogether/domain/user/dto/response/package-info.java
@@ -1,1 +1,0 @@
-package com.gotogether.domain.user.dto.response;

--- a/src/main/java/com/gotogether/domain/user/entity/User.java
+++ b/src/main/java/com/gotogether/domain/user/entity/User.java
@@ -78,4 +78,8 @@ public class User extends BaseEntity {
 	public void updateEmail(String email) {
 		this.email = email;
 	}
+
+	public void updatePhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
+	}
 }

--- a/src/main/java/com/gotogether/domain/user/entity/User.java
+++ b/src/main/java/com/gotogether/domain/user/entity/User.java
@@ -33,7 +33,7 @@ public class User extends BaseEntity {
 	@Column(name = "name", nullable = false)
 	private String name;
 
-	@Column(name = "phone_number")
+	@Column(name = "phone_number", nullable = true, unique = true)
 	private String phoneNumber;
 
 	@Column(name = "email", nullable = false)

--- a/src/main/java/com/gotogether/domain/user/service/UserService.java
+++ b/src/main/java/com/gotogether/domain/user/service/UserService.java
@@ -1,4 +1,8 @@
 package com.gotogether.domain.user.service;
 
+import com.gotogether.domain.user.dto.request.UserRequestDTO;
+import com.gotogether.domain.user.entity.User;
+
 public interface UserService {
+	User createUser(UserRequestDTO request);
 }

--- a/src/main/java/com/gotogether/domain/user/service/UserService.java
+++ b/src/main/java/com/gotogether/domain/user/service/UserService.java
@@ -1,8 +1,11 @@
 package com.gotogether.domain.user.service;
 
 import com.gotogether.domain.user.dto.request.UserRequestDTO;
+import com.gotogether.domain.user.dto.response.UserDetailResponseDTO;
 import com.gotogether.domain.user.entity.User;
 
 public interface UserService {
 	User createUser(UserRequestDTO request);
+
+	UserDetailResponseDTO getDetailUser(Long userId);
 }

--- a/src/main/java/com/gotogether/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,33 @@
 package com.gotogether.domain.user.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.gotogether.domain.user.dto.request.UserRequestDTO;
+import com.gotogether.domain.user.entity.User;
+import com.gotogether.domain.user.repository.UserRepository;
+import com.gotogether.global.apipayload.code.status.ErrorStatus;
+import com.gotogether.global.apipayload.exception.GeneralException;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
-public class UserServiceImpl {
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	@Transactional
+	public User createUser(UserRequestDTO request) {
+
+		User user = userRepository.findById(request.getId())
+			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+		user.updateName(request.getName());
+		user.updatePhoneNumber(request.getPhoneNumber());
+		userRepository.save(user);
+
+		return user;
+	}
 }

--- a/src/main/java/com/gotogether/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/user/service/UserServiceImpl.java
@@ -3,11 +3,12 @@ package com.gotogether.domain.user.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gotogether.domain.event.facade.EventFacade;
+import com.gotogether.domain.user.converter.UserConverter;
 import com.gotogether.domain.user.dto.request.UserRequestDTO;
+import com.gotogether.domain.user.dto.response.UserDetailResponseDTO;
 import com.gotogether.domain.user.entity.User;
 import com.gotogether.domain.user.repository.UserRepository;
-import com.gotogether.global.apipayload.code.status.ErrorStatus;
-import com.gotogether.global.apipayload.exception.GeneralException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,18 +17,27 @@ import lombok.RequiredArgsConstructor;
 public class UserServiceImpl implements UserService {
 
 	private final UserRepository userRepository;
+	private final EventFacade eventFacade;
 
 	@Override
 	@Transactional
 	public User createUser(UserRequestDTO request) {
 
-		User user = userRepository.findById(request.getId())
-			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+		User user = eventFacade.getUserById(request.getId());
 
 		user.updateName(request.getName());
 		user.updatePhoneNumber(request.getPhoneNumber());
 		userRepository.save(user);
 
 		return user;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public UserDetailResponseDTO getDetailUser(Long userId) {
+
+		User user = eventFacade.getUserById(userId);
+		
+		return UserConverter.toUserDetailResponseDTO(user);
 	}
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 카테고리별 이벤트 리스트 조회 API
- request
  requestParam
  category : [DEVELOPMENT_STUDY/NETWORKING/HAKATHON/CONFERENCE]
  page: 0 (default)
  size: 10 (default)

---

- response
<img width="1299" alt="image" src="https://github.com/user-attachments/assets/ce14e3b8-7816-4aae-8936-f095f85f10f3" />

</br></br>

## 유저 수정 API 

- request
  [id, name, phoneNumber, email]

---

- response
      - 성공
`{
  "isSuccess": true,
  "code": "200",
  "message": "OK",
  "result": "userId: 1"
}` 

</br></br>

## 유저 조회 API

- request

---

- response
`{
  "isSuccess": true,
  "code": "200",
  "message": "OK",
  "result": {
    "id": 1,
    "name": "",
    "phoneNumber": "",
    "email": ""
  }
}`


</br></br>

## User 도메인 phoneNumber 필드 제약조건 수정

nullable, unique 지정

</br></br>

## oauth 핸들러 수정

기존엔 소셜 로그인 후 유저 데이터가 생긴 후 해당 유저 정보를 통해 토큰 발급
-> 초기 소셜 로그인시 전화번호가 null 이므로 해당 경우 회원가입 페이지로 리다이렉트

## PR
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.