### PR TITLE
[fix] 스케쥴러 등록 시 동일 트리커 생성되는 오류 수정

### DIFF
--- a/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/event/service/EventServiceImpl.java
@@ -87,6 +87,7 @@ public class EventServiceImpl implements EventService {
 		Event event = eventFacade.getEventById(eventId);
 		hashtagService.deleteHashtagsByEvent(event);
 
+		eventScheduler.deleteScheduledEventJob(eventId);
 		eventRepository.delete(event);
 	}
 

--- a/src/main/java/com/gotogether/domain/reservationemail/service/ReservationEmailServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/reservationemail/service/ReservationEmailServiceImpl.java
@@ -76,6 +76,7 @@ public class ReservationEmailServiceImpl implements ReservationEmailService {
 	@Transactional
 	public void deleteReservationEmail(Long reservationEmailId) {
 		ReservationEmail reservationEmail = reservationEmailFacade.getReservationEmailById(reservationEmailId);
+		eventScheduler.deleteScheduledEmailJob(reservationEmailId);
 		reservationEmailRepository.delete(reservationEmail);
 	}
 

--- a/src/main/java/com/gotogether/domain/ticket/service/TicketServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/ticket/service/TicketServiceImpl.java
@@ -54,6 +54,7 @@ public class TicketServiceImpl implements TicketService {
 	@Transactional
 	public void deleteTicket(Long ticketId) {
 		Ticket ticket = getTicketById(ticketId);
+		eventScheduler.deleteScheduledTicketJob(ticketId);
 		ticketRepository.delete(ticket);
 	}
 

--- a/src/main/java/com/gotogether/global/scheduler/EventScheduler.java
+++ b/src/main/java/com/gotogether/global/scheduler/EventScheduler.java
@@ -8,4 +8,10 @@ public interface EventScheduler {
 	void scheduleUpdateEventStatus(Long eventId, LocalDateTime eventDate);
 
 	void scheduleUpdateTicketStatus(Long ticketId, LocalDateTime eventDate);
+
+	void deleteScheduledEmailJob(Long id);
+
+	void deleteScheduledEventJob(Long id);
+	
+	void deleteScheduledTicketJob(Long id);
 }

--- a/src/main/java/com/gotogether/global/scheduler/QuartzJobScheduler.java
+++ b/src/main/java/com/gotogether/global/scheduler/QuartzJobScheduler.java
@@ -29,7 +29,7 @@ public class QuartzJobScheduler implements EventScheduler {
 		String jobDataKey, Long id, Date startTime) {
 		try {
 			JobDetail jobDetail = createJobDetail(jobClass, jobIdentity, jobDataKey, id);
-			Trigger trigger = createTrigger(triggerIdentity, startTime);
+			Trigger trigger = createTrigger(triggerIdentity, id, startTime);
 
 			scheduler.scheduleJob(jobDetail, trigger);
 		} catch (SchedulerException e) {
@@ -46,9 +46,9 @@ public class QuartzJobScheduler implements EventScheduler {
 			.build();
 	}
 
-	private Trigger createTrigger(String triggerIdentity, Date startTime) {
+	private Trigger createTrigger(String triggerIdentity, Long id, Date startTime) {
 		return TriggerBuilder.newTrigger()
-			.withIdentity(triggerIdentity)
+			.withIdentity(triggerIdentity + "-" + id)
 			.startAt(startTime)
 			.withSchedule(SimpleScheduleBuilder.simpleSchedule()
 				.withMisfireHandlingInstructionFireNow())


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🐞트리거 생성 시 엔티티 고유 id를 통해 생성되도록 수정
<img width="867" alt="image" src="https://github.com/user-attachments/assets/0f703f18-fa4a-4f9d-9ddf-928a820f7ef6" />

---

## 🐞예약메일, 이벤트, 티켓 삭제 API 시 등록된 스케쥴러도 삭제 되도록 수정
<img width="849" alt="image" src="https://github.com/user-attachments/assets/da8a2317-0bcd-42ce-8f08-dec0937bf0d9" />
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/a2623378-cf1a-4b07-9f28-68ea623ac963" />

- 스케쥴러 삭제 로직 구현


## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.