### PR TITLE
[fix] 주문 조회 응답 수정 및 이벤트 상세 조회 필드 수정

### DIFF
--- a/src/main/java/com/gotogether/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/gotogether/domain/event/converter/EventConverter.java
@@ -62,6 +62,14 @@ public class EventConverter {
 			.organizerEmail(event.getOrganizerEmail())
 			.organizerPhoneNumber(event.getOrganizerPhoneNumber())
 			.referenceLinks(links)
+			.category(String.valueOf(event.getCategory()))
+			.onlineType(String.valueOf(event.getOnlineType()))
+			.status(String.valueOf(event.getStatus()))
+
+			.hashtags(event.getHashtags().stream()
+				.map(Hashtag::getName)
+				.collect(Collectors.toList()))
+
 			.build();
 	}
 

--- a/src/main/java/com/gotogether/domain/event/dto/response/EventDetailResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/event/dto/response/EventDetailResponseDTO.java
@@ -27,4 +27,8 @@ public class EventDetailResponseDTO {
 	private String organizerEmail;
 	private String organizerPhoneNumber;
 	private List<ReferenceLinkDTO> referenceLinks;
+	private String category;
+	private String onlineType;
+	private String status;
+	private List<String> hashtags;
 }

--- a/src/main/java/com/gotogether/domain/hostchannel/converter/HostChannelConverter.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/converter/HostChannelConverter.java
@@ -16,8 +16,6 @@ import com.gotogether.domain.hostchannel.dto.response.HostDashboardResponseDTO;
 import com.gotogether.domain.hostchannel.dto.response.ParticipantManagementResponseDTO;
 import com.gotogether.domain.hostchannel.entity.HostChannel;
 import com.gotogether.domain.order.entity.Order;
-import com.gotogether.domain.order.entity.OrderStatus;
-import com.gotogether.domain.ticketqrcode.entity.TicketStatus;
 
 public class HostChannelConverter {
 
@@ -100,9 +98,8 @@ public class HostChannelConverter {
 			.phoneNumber(order.getUser().getPhoneNumber())
 			.purchaseDate(order.getCreatedAt().format(DATE_FORMATTER))
 			.ticketName(order.getTicket().getName())
-			.isCheckedIn(
-				order.getTicketQrCode() != null && TicketStatus.USED.equals(order.getTicketQrCode().getStatus()))
-			.isApproved(order.getStatus() != null && order.getStatus().equals(OrderStatus.COMPLETED))
+			.isCheckedIn(order.getTicketQrCode().getStatus().isCheckIn())
+			.orderStatus(order.getStatus().name())
 			.build();
 	}
 

--- a/src/main/java/com/gotogether/domain/hostchannel/dto/response/ParticipantManagementResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/dto/response/ParticipantManagementResponseDTO.java
@@ -14,5 +14,5 @@ public class ParticipantManagementResponseDTO {
 	private String purchaseDate;
 	private String ticketName;
 	private boolean isCheckedIn;
-	private boolean isApproved;
+	private String orderStatus;
 }

--- a/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/hostchannel/service/HostChannelServiceImpl.java
@@ -193,7 +193,7 @@ public class HostChannelServiceImpl implements HostChannelService {
 			List<Order> orders = orderRepository.findByTicketAndStatus(ticket, OrderStatus.COMPLETED);
 
 			totalTicketCnt += orders.size();
-			totalPrice += orders.size() * ticket.getPrice();
+			totalPrice += (long)orders.size() * ticket.getPrice();
 		}
 
 		return HostChannelConverter.toHostDashboardResponseDTO(event, totalTicketCnt, totalPrice);

--- a/src/main/java/com/gotogether/domain/order/controller/OrderController.java
+++ b/src/main/java/com/gotogether/domain/order/controller/OrderController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.gotogether.domain.order.dto.request.OrderRequestDTO;
-import com.gotogether.domain.order.dto.response.OrderedDetailResponseDTO;
+import com.gotogether.domain.order.dto.response.OrderDetailResponseDTO;
 import com.gotogether.domain.order.dto.response.OrderedTicketResponseDTO;
 import com.gotogether.domain.order.entity.Order;
 import com.gotogether.domain.order.service.OrderService;
@@ -53,7 +53,7 @@ public class OrderController {
 	}
 
 	@GetMapping("/{orderId}")
-	public ApiResponse<OrderedDetailResponseDTO> getDetailOrder(@AuthUser Long userId,
+	public ApiResponse<OrderDetailResponseDTO> getDetailOrder(@AuthUser Long userId,
 		@PathVariable Long orderId) {
 		return ApiResponse.onSuccess(orderService.getDetailOrder(userId, orderId));
 	}

--- a/src/main/java/com/gotogether/domain/order/converter/OrderConverter.java
+++ b/src/main/java/com/gotogether/domain/order/converter/OrderConverter.java
@@ -2,11 +2,13 @@ package com.gotogether.domain.order.converter;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
 import com.gotogether.domain.event.entity.Event;
-import com.gotogether.domain.order.dto.response.OrderedDetailResponseDTO;
+import com.gotogether.domain.hashtag.entity.Hashtag;
+import com.gotogether.domain.order.dto.response.OrderDetailResponseDTO;
 import com.gotogether.domain.order.dto.response.OrderedTicketResponseDTO;
 import com.gotogether.domain.order.entity.Order;
 import com.gotogether.domain.order.entity.OrderStatus;
@@ -32,9 +34,17 @@ public class OrderConverter {
 			.title(order.getTicket().getEvent().getTitle())
 			.hostChannelName(order.getTicket().getEvent().getHostChannel().getName())
 			.startDate(order.getTicket().getEvent().getStartDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
-			.eventAddress(order.getTicket().getEvent().getAddress())
+			.address(order.getTicket().getEvent().getAddress())
+
+			.hashtags(order.getTicket().getEvent().getHashtags().stream()
+				.map(Hashtag::getName)
+				.collect(Collectors.toList()))
+
+			.ticketQrCode(order.getTicketQrCode().getQrCodeImageUrl())
 			.ticketName(order.getTicket().getName())
-			.ticketStatus(order.getStatus().name())
+			.orderStatus(order.getStatus().name())
+			.isCheckIn(order.getTicketQrCode().getStatus().isCheckIn())
+
 			.remainDays(getDdayStatus(
 				LocalDate.from(order.getTicket().getEvent().getStartDate()),
 				LocalDate.from(order.getTicket().getEvent().getEndDate())))
@@ -57,9 +67,9 @@ public class OrderConverter {
 		}
 	}
 
-	public static OrderedDetailResponseDTO toOrderedDetailResponseDTO(
+	public static OrderDetailResponseDTO toOrderedDetailResponseDTO(
 		Order order, Event event, Ticket ticket) {
-		return OrderedDetailResponseDTO.builder()
+		return OrderDetailResponseDTO.builder()
 			.id(order.getId())
 			.ticketQrCode(order.getTicketQrCode().getQrCodeImageUrl())
 			.title(event.getTitle())
@@ -68,7 +78,7 @@ public class OrderConverter {
 			.eventAddress(event.getAddress())
 			.ticketName(order.getTicket().getName())
 			.ticketPrice(order.getTicket().getPrice())
-			.ticketStatus(order.getTicketQrCode().getStatus().name())
+			.orderStatus(order.getTicketQrCode().getStatus().name())
 			.remainDays(getDdayStatus(
 				LocalDate.from(event.getStartDate()),
 				LocalDate.from(event.getEndDate())))

--- a/src/main/java/com/gotogether/domain/order/dto/response/OrderDetailResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/order/dto/response/OrderDetailResponseDTO.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class OrderedDetailResponseDTO {
+public class OrderDetailResponseDTO {
 	private Long id;
 	private String ticketQrCode;
 	private String title;
@@ -14,6 +14,6 @@ public class OrderedDetailResponseDTO {
 	private String eventAddress;
 	private String ticketName;
 	private int ticketPrice;
-	private String ticketStatus;
+	private String orderStatus;
 	private String remainDays;
 }

--- a/src/main/java/com/gotogether/domain/order/dto/response/OrderedTicketResponseDTO.java
+++ b/src/main/java/com/gotogether/domain/order/dto/response/OrderedTicketResponseDTO.java
@@ -1,5 +1,7 @@
 package com.gotogether.domain.order.dto.response;
 
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,8 +14,12 @@ public class OrderedTicketResponseDTO {
 	private String title;
 	private String hostChannelName;
 	private String startDate;
-	private String eventAddress;
+	private String address;
+	private List<String> hashtags;
+	private String ticketQrCode;
 	private String ticketName;
-	private String ticketStatus;
+	private int ticketPrice;
+	private String orderStatus;
+	private boolean isCheckIn;
 	private String remainDays;
 }

--- a/src/main/java/com/gotogether/domain/order/service/OrderService.java
+++ b/src/main/java/com/gotogether/domain/order/service/OrderService.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.gotogether.domain.order.dto.request.OrderRequestDTO;
-import com.gotogether.domain.order.dto.response.OrderedDetailResponseDTO;
+import com.gotogether.domain.order.dto.response.OrderDetailResponseDTO;
 import com.gotogether.domain.order.dto.response.OrderedTicketResponseDTO;
 import com.gotogether.domain.order.entity.Order;
 
@@ -15,7 +15,7 @@ public interface OrderService {
 
 	Page<OrderedTicketResponseDTO> getPurchasedTickets(Long userId, Pageable pageable);
 
-	OrderedDetailResponseDTO getDetailOrder(Long userId, Long orderId);
+	OrderDetailResponseDTO getDetailOrder(Long userId, Long orderId);
 
 	void cancelOrder(Long userId, Long orderId);
 }

--- a/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/gotogether/domain/order/service/OrderServiceImpl.java
@@ -13,7 +13,7 @@ import com.gotogether.domain.event.entity.Event;
 import com.gotogether.domain.event.facade.EventFacade;
 import com.gotogether.domain.order.converter.OrderConverter;
 import com.gotogether.domain.order.dto.request.OrderRequestDTO;
-import com.gotogether.domain.order.dto.response.OrderedDetailResponseDTO;
+import com.gotogether.domain.order.dto.response.OrderDetailResponseDTO;
 import com.gotogether.domain.order.dto.response.OrderedTicketResponseDTO;
 import com.gotogether.domain.order.entity.Order;
 import com.gotogether.domain.order.entity.OrderStatus;
@@ -66,7 +66,7 @@ public class OrderServiceImpl implements OrderService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public OrderedDetailResponseDTO getDetailOrder(Long userId, Long orderId) {
+	public OrderDetailResponseDTO getDetailOrder(Long userId, Long orderId) {
 		User user = eventFacade.getUserById(userId);
 
 		Order order = orderRepository.findById(orderId)

--- a/src/main/java/com/gotogether/domain/ticketqrcode/entity/TicketStatus.java
+++ b/src/main/java/com/gotogether/domain/ticketqrcode/entity/TicketStatus.java
@@ -1,5 +1,16 @@
 package com.gotogether.domain.ticketqrcode.entity;
 
 public enum TicketStatus {
-	AVAILABLE, USED
+	AVAILABLE(false),
+	USED(true);
+
+	private final boolean isCheckIn;
+
+	TicketStatus(boolean isCheckIn) {
+		this.isCheckIn = isCheckIn;
+	}
+
+	public boolean isCheckIn() {
+		return isCheckIn;
+	}
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#55 

## 🐞주문 조회 API 상태 필드명 수정

- 기존 응답 `ticketStatus` 에서 `orderStatus`로 필드명 수정

- 구매/참자가 관리 필드도 마찬가지로 변경

<img width="301" alt="image" src="https://github.com/user-attachments/assets/5e442622-b415-4799-9ad4-7dcfaec08ef5" />


---

## 🐞해시태그 응답 추가

- 주문 조회 시 해당 이벤트에 대한 해시태그 값들도 응답

---

## 🐞 체크인 여부 응답 추가

- 구매한 티켓에 대한 체크인 여부 응답


## 최종 응답
<img width="496" alt="image" src="https://github.com/user-attachments/assets/8f424623-0985-4a11-88ac-c48a252c2572" />


## 🐞이벤트 상세 조회 시 엔티티 필드 값 모두 추가
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7524d348-d1b4-4274-acb7-c635ec11908d" />

- 이벤트 수정을 위해 필요한 필드 값들 조회 시 응답


## PR
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷 변경, 세미콜론 누락, 코드 수정이 없는경우
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 수정, 패키지 매니저 수정
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제

## Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 필요 없는 import문이나 setter 등을 삭제했습니다.
- [x] 기존의 코드에 영향이 없는 것을 확인했습니다.